### PR TITLE
DDCE-7560 Trusts obliged entity stub: Update repository.yaml to Match Standardized Format

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "10.1.0"
+  private val bootstrapVersion = "10.3.0"
 
   private val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"             %% "bootstrap-backend-play-30"  % bootstrapVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,6 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.8")
+addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.9")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"         % "2.3.1")
 addSbtPlugin("com.timushev.sbt"  % "sbt-updates"           % "0.6.4")

--- a/repository.yaml
+++ b/repository.yaml
@@ -6,3 +6,5 @@ service-type: Backend
 test-repositories:
   - trusts-performance-tests
   - trusts-acceptance-tests
+  - trusts-iv-perf-tests
+  - trusts-iv-ui-tests

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,1 +1,8 @@
+digital-service: TRS / Trusts
+description: This service is responsible for stubbing the response for information about the beneficial owners in a trust. This service stubs API#1584 Get Trust Obliged Entities.
 repoVisibility: public_0C3F0CE3E6E6448FAD341E7BFA50FCD333E06A20CFF05FCACE61154DDBBADF71
+type: service
+service-type: Backend
+test-repositories:
+  - trusts-performance-tests
+  - trusts-acceptance-tests


### PR DESCRIPTION
DDCE-7560 Trusts obliged entity stub: Update repository.yaml to Match Standardized Format